### PR TITLE
fix: Correct casing for invoice data

### DIFF
--- a/src/pages/students/StudentInvoice.jsx
+++ b/src/pages/students/StudentInvoice.jsx
@@ -116,15 +116,15 @@ export default function StudentInvoice() {
   };
 
   const handleSubmit = async () => {
-    const { registration_id, CourseID, payment, tax_rate, discount_rate, payment_type, transaction_id } = formData;
+    const { registration_id, CourseID, payment, taxRate, discountRate, paymentType, transactionId } = formData;
     const invoiceData = {
       registration_id,
       CourseID,
       payment,
-      tax_rate,
-      discount_rate,
-      payment_type,
-      transaction_id,
+      tax_rate: taxRate,
+      discount_rate: discountRate,
+      payment_type: paymentType,
+      transaction_id: transactionId,
     };
 
     try {


### PR DESCRIPTION
Resolved the 'Unknown column \'NaN\' in \'field list\'' error by correcting the casing of keys in the invoice data object sent to the backend. The frontend state uses camelCase (e.g., taxRate), while the backend API expects snake_case (e.g., tax_rate). The handleSubmit function in StudentInvoice.jsx has been updated to correctly map the state to the API's expected format.